### PR TITLE
fix 404 page

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -3,17 +3,17 @@ import Head from 'next/head'
 export default function Layout(props) {
 
   return (
-    <>
+    <div className="h-screen">
       <Head>
         <title>Sample title</title>
         <meta name="description" content="sample" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main>
-        <div>
+      <main className="h-full">
+        <div className="h-full">
         {props.children}
         </div>
       </main>
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
"min-h-full" sets the minimum height of an element to match the height of its parent container.
However, in this case, the height of the parent element is not defined. To resolve this issue, you should set the height of the top-level element to "h-screen", which ensures it takes up the full height of the viewport.
Then, set the height of the parent elements to "h-full" to make them inherit the full height.

Robert.